### PR TITLE
fix: align README with standard TestMu AI template

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@
 
 ## Getting Started
 
-TestMu AI (Formerly LambdaTest) is an AI-native, multi-agent quality engineering platform that enables teams to plan, author, execute, analyze, and optimize tests at scale across browsers, devices, and frameworks.
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks.
 
-This Bitrise step uploads a provided app APK and test APK to TestMu AI (Formerly LambdaTest) and executes Espresso Tests for the provided APKs using App Automate.
+With TestMu AI (Formerly LambdaTest), you can run Espresso Tests With Bitrise CI across real browsers and operating systems.
 
 - [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
 - Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
+### Prerequisites
 
-This step uploads a provided app apk and test apk to TestMu AI (Formerly LambdaTest). It then will execute the Espresso Tests for the provided apks in TestMu AI (Formerly LambdaTest) app automate.
-
+- A TestMu AI (Formerly LambdaTest) account with your username and access key
 
 ## How to use this Step
 
@@ -106,7 +106,6 @@ You can share your Step or step version with the [bitrise CLI](https://github.co
 1. Send the Pull Request, as described in the logs of `bitrise run share-this-step`
 
 That's all ;)
-
 
 ## TestMu AI (Formerly LambdaTest) Community
 


### PR DESCRIPTION
Full README restructure to match standard template: correct Getting Started, Prerequisites, Community/Certs/Learning blocks, License at end.